### PR TITLE
Swaps deprecated `--local` for `--nodocker`

### DIFF
--- a/docs/hackathon/startup-guide.md
+++ b/docs/hackathon/startup-guide.md
@@ -37,7 +37,7 @@ This will ask you for account id to run validator on \(if you want to just run a
 
 If you want to check the logs inside the docker, you can use `docker logs --follow nearcore`.
 
-Alternatively, you can build and run validator on this machine, just use `--local` flag to switch off the Docker. This will install Rust and compile the binary.
+Alternatively, you can build and run validator on this machine, just use `--nodocker` flag to switch off the Docker. This will install Rust and compile the binary.
 
 ## Running official TestNet on GCP
 
@@ -109,8 +109,8 @@ You need to do two things in order to access your smart contract calls on the fr
 ```javascript
 // Initializing our contract APIs by contract name and configuration.
 window.contract = await near.loadContract(config.contractName, {
-...  
-  // View methods are read only. They don't modify the state, but usually return some value. 
+...
+  // View methods are read only. They don't modify the state, but usually return some value.
   viewMethods: ["hello"],
   // Change methods can modify the state. But you don't receive the returned value when called.
   changeMethods: [],

--- a/docs/local-setup/running-testnet-windows.md
+++ b/docs/local-setup/running-testnet-windows.md
@@ -11,7 +11,7 @@ sidebar_label: Running testnet on Windows
     Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux
     ```
     Then restart your computer.
-2. Go to your Microsoft Store and look for Ubuntu; this is the Ubuntu Terminal instance. Install and launch it. 
+2. Go to your Microsoft Store and look for Ubuntu; this is the Ubuntu Terminal instance. Install and launch it.
 3. Now you might be asked for username and password, do not use admin as username.
 4. Your Ubuntu Instance does not have OpenSSL, which you will need to run the node. To download OpenSSL, please run the following commands in the Ubuntu Terminal:
     ```bash
@@ -64,7 +64,7 @@ sidebar_label: Running testnet on Windows
     ```bash
     sudo apt-get install pkg-config libssl-dev
     ```
-    Great! All set to get the node up and running! 
+    Great! All set to get the node up and running!
 11. Create a new directory:
     ```bash
     mkdir nearprotocol (you can name this however you like)
@@ -80,7 +80,7 @@ sidebar_label: Running testnet on Windows
     ```bash
     sudo apt install -y git binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev cmake gcc g++ python docker.io protobuf-compiler
     ```
-14. Clone the github nearcore 
+14. Clone the github nearcore
     ```bash
     git clone https://github.com/nearprotocol/nearcore.git
     ```
@@ -90,8 +90,8 @@ sidebar_label: Running testnet on Windows
     ```
 Final: And now run the testnet:
     ```
-    sudo ./scripts/start_testnet.py --local
+    sudo ./scripts/start_testnet.py --nodocker
     ```
 
- 
+
  You might be asked for a validator ID; if you do not want to validate, simply press enter. For validation, please refer to the validation section in the docs. (https://docs.nearprotocol.com/running-a-node/staking-validator)

--- a/docs/local-setup/running-testnet.md
+++ b/docs/local-setup/running-testnet.md
@@ -21,11 +21,11 @@ Follow next instructions to install Docker on your machine:
 
 The following instructions will only work once you're running Docker on your machine.
 
-_NOTE: We don't recommend this unless you're contributing to `nearcore` or you know what you're trying to do, but you can run a node without docker by adding the `--local` flag to the start testnet script found below. See how to do this under_ [_Compile TestNet without Docker_](./#compile-testnet-without-docker)_._
+_NOTE: We don't recommend this unless you're contributing to `nearcore` or you know what you're trying to do, but you can run a node without docker by adding the `--nodocker` flag to the start testnet script found below. See how to do this under_ [_Compile TestNet without Docker_](./#compile-testnet-without-docker)_._
 
 ## Running official TestNet node with Docker
 
-To run locally, clone the `nearcore` repo. 
+To run locally, clone the `nearcore` repo.
 
 ```bash
 git clone https://github.com/nearprotocol/nearcore.git
@@ -61,17 +61,17 @@ A node will then start in the background inside the docker. To check the logs in
 
 ![text-alt](assets/docker-logs.png)
 
-**Legend:**   
-**\# 7153** \| BlockHeight  
-**V/1** \| _'V'_ \(validator\) or _'—'_ \(regular node\) / Total Validators  
-**0/0/40** \| connected peers / up to date peers / max peers 
+**Legend:**
+**\# 7153** \| BlockHeight
+**V/1** \| _'V'_ \(validator\) or _'—'_ \(regular node\) / Total Validators
+**0/0/40** \| connected peers / up to date peers / max peers
 
-If you're interested in becoming a validator, take a look at: 
+If you're interested in becoming a validator, take a look at:
 
 
 ## Compile TestNet without Docker
 
-Alternatively, you can build and run validator on this machine without docker by using the `--local` flag. This will install Rust and compile the binary.
+Alternatively, you can build and run validator on this machine without docker by using the `--nodocker` flag. This will install Rust and compile the binary.
 
 For Mac OS, make sure you have developer tools installed \(like git\) and then use `brew` to install extra tools:
 
@@ -93,17 +93,17 @@ git clone https://github.com/nearprotocol/nearcore.git
 cd nearcore
 ```
 
-Finally:  
+Finally:
 On MacOS
 
 ```bash
-./scripts/start_testnet.py --local
+./scripts/start_testnet.py --nodocker
 ```
 
 On Ubuntu
 
 ```bash
-sudo ./scripts/start_testnet.py --local
+sudo ./scripts/start_testnet.py --nodocker
 ```
 
 ## Running official TestNet on GCP


### PR DESCRIPTION
Hi 👋 ,

I noticed the [start_testnet.py](https://github.com/nearprotocol/nearcore/blob/0c2112b8bc42bc4c37da6bc0a24a819fda5d7a5c/scripts/start_testnet.py) script advises the user to pass `--nodocker` in rather than `--local`. I thought it might be helpful to submit a PR with a doc update. 👍 

Best,
Arthur