### PR TITLE
Update running-testnet.md

### DIFF
--- a/docs/local-setup/running-testnet.md
+++ b/docs/local-setup/running-testnet.md
@@ -37,6 +37,13 @@ git clone https://github.com/nearprotocol/nearcore.git
 cd nearcore
 ```
 
+`checkout` to latest development version of start script:
+```bash
+git checkout staging
+```
+
+To enable coredump for docker, do `echo '/tmp/core.%t.%e.%p' | sudo tee /proc/sys/kernel/core_pattern` to modify system coredump location to `/tmp`.
+
 and then run `./scripts/start_testnet.py`
 
 On MacOS


### PR DESCRIPTION
Test on mac is appreciated!! only tested on ubuntu.
step to test: add
```
    let r1 = 0 as *const i32;

    unsafe {
        println!("r1 is: {}", *r1);
    }
```
at the begining of near/src/main.rs to create a segment fault.

make to create a local docker image `nearcore`

do as this doc

you should observe coredump in /tmp (in host)

(and it should containing backtrace, after docker cp near binary out and gdb binary-path coredump-path (this step isn't testable on mac, as the binary is for linux)