### PR TITLE
Minor documentation changes: broken links

### DIFF
--- a/docs/api/quickstart.md
+++ b/docs/api/quickstart.md
@@ -19,18 +19,18 @@ We welcome members of our community to add other language bindings and will be h
 The best source of examples across the platform is currently the tests.  Some parts of the system are also documented with introductions and examples.  Everything is open source.
 
 ### JavaScript (`nearlib`)
-- documentation is [here](https://docs.nearprotocol.com/docs/development/examples/nearlib/introduction)
-- examples are [here](https://docs.nearprotocol.com/docs/development/examples/nearlib/examples)
+- documentation is [here](/docs/roles/developer/examples/nearlib/introduction)
+- examples are [here](/docs/roles/developer/examples/nearlib/examples)
 - source code is [here](https://github.com/nearprotocol/nearlib/tree/master/src.ts)
 
 ### Rust (`near-bindgen`)
-- documentation is [here](https://docs.nearprotocol.com/docs/near-bindgen/near-bindgen)
+- documentation is [here](/docs/near-bindgen/near-bindgen)
 - examples are [here](https://github.com/nearprotocol/near-bindgen/tree/master/examples)
 - source code is [here](https://github.com/nearprotocol/near-bindgen)
 
 ### JSON-RPC
-- documentation is [here](https://docs.nearprotocol.com/docs/interaction/rpc)
-- examples are [here](/docs/development/examples/nearlib/examples#jsonrpcprovider)
+- documentation is [here](/docs/interaction/rpc)
+- examples are [here](/docs/roles/developer/examples/nearlib/examples#jsonrpcprovider)
 - source code is [here](https://github.com/nearprotocol/nearlib/blob/master/src.ts/providers/json-rpc-provider.ts)
 
 ## Getting Help

--- a/docs/contribution/contribution-overview.md
+++ b/docs/contribution/contribution-overview.md
@@ -79,6 +79,6 @@ Please pay attention to the maintainer's feedback, since its a necessary step to
 
 ## All set!
 
-If you have any questions feel free to post them to our [discord channel](https://discordapp.com/invite/gBtUFKR).
+If you have any questions feel free to post them to our [discord channel](http://near.chat).
 
 Thanks for your time and code!

--- a/docs/tutorials/zero-to-hero.md
+++ b/docs/tutorials/zero-to-hero.md
@@ -623,7 +623,7 @@ Great Job! If you want to see the above code with a more polished front end, you
 
 Of course our Oracle implementation is lacking in various aspects. So feel free to implement your own improvements, or use your new found skills to build something completely different. If you'd like to contribute to this tutorial, open up a pull request!
 
-If you run into any problems, want to share some of the cool things you've built, or just want to get more involved with the Near community, join our [discord channel](https://discordapp.com/invite/gBtUFKR). Everyone is super friendly. \(Really!\)
+If you run into any problems, want to share some of the cool things you've built, or just want to get more involved with the Near community, join our [discord channel](http://near.chat). Everyone is super friendly. \(Really!\)
 
 **Other Tutorials + Topics to cover**
 


### PR DESCRIPTION
I noticed a few links that were giving "Not found"
Pretty simple changes, including using relative paths as used in the previous version's JSON-RPC examples link. Made the rest of them consistent.
Tested to make sure with `docker-compose build` and `docker-compose up`

Nice to see that these repos build and serve as expected.