### PR TITLE
Content.fix—remove—home dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ website/secrets.env
 website/build/*
 website/i18n/*
 neardev
+.idea


### PR DESCRIPTION
Quick fix removing the documentation surround `--homeDir`
Recently discussion about needing/not-needing this here, ultimately removed and merged:
https://github.com/nearprotocol/near-shell/pull/250