### PR TITLE
Content.fix—cross contract comments test

### DIFF
--- a/docs/tutorials/how-to-write-contracts-that-talk-to-each-other.md
+++ b/docs/tutorials/how-to-write-contracts-that-talk-to-each-other.md
@@ -371,9 +371,9 @@ export function calculate({ a, b }): void {
 }
 ```
 
-This is a bit confusing because the contract is returning a promise, but because it's calling a function elsewhere, the compiler thinks that this is returning void.
+You may notice this function returns `void`, which is a bit confusing because the contract is returning a promise. This is because it's calling a function elsewhere and the compiler thinks it's void.
 
-(For now, you can set the return type of the function to `void`. In future releases this will be changed.)
+(In future releases this will be changed.)
 
 ## Step 6 - More Tests!
 

--- a/docs/tutorials/how-to-write-contracts-that-talk-to-each-other.md
+++ b/docs/tutorials/how-to-write-contracts-that-talk-to-each-other.md
@@ -94,19 +94,23 @@ We're interested in writing only one function for this example. A function that 
 import { context, storage } from "near-runtime-ts";
 
 export function addLongNumbers(a: string, b: string): string {
+  // Similar to long addition by hand, we start with the least significant digits first
   const aReversed = a.split("").reverse();
   const bReversed = b.split("").reverse();
 
+  // We initiatize our resultant variable to be one more than the largest number's length
   const maxLength = max(a.length, b.length);
   let resultArray = new Array<String | null>(maxLength + 1);
   let result = "";
   let carry = 0;
 
+  // Loop through each digit adding the value to the other number, if it exists
   for (let i = 0; i < maxLength; ++i) {
     let aDigit = (i < a.length) ? U32.parseInt(aReversed[i]) : 0;
     let bDigit = (i < b.length) ? U32.parseInt(bReversed[i]) : 0;
     let digitSum = aDigit + bDigit + carry;
 
+    // Keep track of the carry amount
     if (digitSum >= 10) {
       carry = 1;
       digitSum -= 10;
@@ -117,10 +121,12 @@ export function addLongNumbers(a: string, b: string): string {
     resultArray[i] = digitSum.toString();
   }
 
+  // If the final addition has a carry, add it to the extra slot we initialized for it
   if (carry > 0) {
     resultArray[maxLength] = carry.toString();
   }
 
+  // Reverse again and combine the values for the final result
   let reversedResultArray = resultArray.reverse();
   return reversedResultArray.join("");
 }

--- a/docs/tutorials/how-to-write-contracts-that-talk-to-each-other.md
+++ b/docs/tutorials/how-to-write-contracts-that-talk-to-each-other.md
@@ -322,6 +322,15 @@ We're also using the `AddArgs` model we created to package the strings we want t
 > - The ID of the contract that we created before. **You'll need to replace this with your own.**
 > - Whatever function we're trying to call on the `Calculator` contract.
 
+<blockquote class="warning">
+<strong>heads up</strong><br><br>
+
+The following code will fail with the error `Exceeded gas limit`
+
+This issue is being [tracked here](https://github.com/nearprotocol/nearlib/issues/176)
+
+</blockquote>
+
 ```ts
 const OTHER_CONTRACT = "studio-REPLACE_THIS_IDENTIFIER";
 

--- a/docs/tutorials/how-to-write-contracts-that-talk-to-each-other.md
+++ b/docs/tutorials/how-to-write-contracts-that-talk-to-each-other.md
@@ -322,15 +322,6 @@ We're also using the `AddArgs` model we created to package the strings we want t
 > - The ID of the contract that we created before. **You'll need to replace this with your own.**
 > - Whatever function we're trying to call on the `Calculator` contract.
 
-<blockquote class="warning">
-<strong>heads up</strong><br><br>
-
-The following code will fail with the error `Exceeded gas limit`
-
-This issue is being [tracked here](https://github.com/nearprotocol/nearlib/issues/176)
-
-</blockquote>
-
 ```ts
 const OTHER_CONTRACT = "studio-REPLACE_THIS_IDENTIFIER";
 

--- a/docs/tutorials/how-to-write-contracts-that-talk-to-each-other.md
+++ b/docs/tutorials/how-to-write-contracts-that-talk-to-each-other.md
@@ -194,8 +194,8 @@ describe("Calculator", function() {
 
     it("should work with second string longer", async function() {
       const params = {
-        a: "15",
-        b: "4"
+        a: "4",
+        b: "15"
       };
       const result = await contract.addLongNumbers(params);
       expect(result).toBe("19");


### PR DESCRIPTION
Minor cleanup on an awesome article. I also removed a warning about the gas being exceeded because I see this issue has been addressed and closed here:
https://github.com/nearprotocol/nearlib/issues/176