### PR TITLE
add external link explaining why wasm32-unknown-unknown

### DIFF
--- a/docs/local-setup/local-dev-node.md
+++ b/docs/local-setup/local-dev-node.md
@@ -23,6 +23,10 @@ sidebar_label: Local Development on Local Network
   - `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
 - Add wasm target to your toolchain
   - `rustup target add wasm32-unknown-unknown`
+  
+<blockquote class="info">
+  <a href="https://github.com/rustwasm/wasm-bindgen/issues/979#issuecomment-432633971" target="_blank">Why <code>unknown-unknown</code>?</a>
+</blockquote>  
 
 *(see here for more details https://github.com/nearprotocol/near-bindgen#pre-requisites)*
 

--- a/docs/local-setup/local-dev-testnet.md
+++ b/docs/local-setup/local-dev-testnet.md
@@ -24,6 +24,10 @@ sidebar_label: Local Development on TestNet
   - `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`
 - Add wasm target to your toolchain
   - `rustup target add wasm32-unknown-unknown`
+  
+<blockquote class="info">
+  <a href="https://github.com/rustwasm/wasm-bindgen/issues/979#issuecomment-432633971" target="_blank">Why <code>unknown-unknown</code>?</a>
+</blockquote>  
 
 *(see here for more details https://github.com/nearprotocol/near-bindgen#pre-requisites)*
 

--- a/docs/near-bindgen/near-bindgen.md
+++ b/docs/near-bindgen/near-bindgen.md
@@ -105,6 +105,9 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```bash
 rustup target add wasm32-unknown-unknown
 ```
+<blockquote class="info">
+  <a href="https://github.com/rustwasm/wasm-bindgen/issues/979#issuecomment-432633971" target="_blank">Why <code>unknown-unknown</code>?</a>
+</blockquote>
 
 ## Writing Rust Contract
 You can follow the [examples/status-message](https://github.com/nearprotocol/near-bindgen/tree/master/examples/status-message) crate that shows a simple Rust contract.


### PR DESCRIPTION
Very simple addition of an external link showing a core maintainer of wasm explaining the "unknown-unknown" which sounds may sound scary to developers.
In this case, I didn't use markdown links because I want to make sure they have `target="_blank"`