### PR TITLE
overhauled initial developer experience in docs

### DIFF
--- a/docs/roles/developer/quickstart.md
+++ b/docs/roles/developer/quickstart.md
@@ -29,11 +29,10 @@ The fastest way to get started is to use NEAR Studio (limited to web application
   - Explore levels of abstraction in `nearlib`
   - Send yourself money (after hacking on our wallet storage to learn how it works)
 - Follow our end-to-end guided walkthroughs to
+  - [Zero to Hero](/docs/tutorials/zero-to-hero)
   - [Issue a token](/docs/tutorials/near-studio/token)
   - [Call one smart contract from another](/docs/tutorials/how-to-write-contracts-that-talk-to-each-other)
-  - [Implement an oracle](/docs/tutorials/zero-to-hero)
   - [Test smart contracts](/docs/tutorials/test-your-smart-contracts)
-
 
 ## Smart Contract Development
 

--- a/docs/roles/developer/tutorials/introduction.md
+++ b/docs/roles/developer/tutorials/introduction.md
@@ -10,33 +10,15 @@ Each of the tutorials below includes a rough estimate of the time needed to comp
 
 All of these tutorials are accessible to anyone with some background in software development using any modern programming language, especially JavaScript.
 
-## Sample Applications
+## Guided Walkthroughs
 
-### [NEAR Wallet Integration](/docs/tutorials/near-studio/near-wallet-integration)
+### [Zero to Hero (START HERE)](/docs/tutorials/zero-to-hero)
 
-*description*
-
-| duration | directions | difficulty |
-|:---------|:-----------|:-----------|
-| 30 mins  | ~5 steps   | Trivial    |
-
-
-### [Counter Smart Contract](/docs/tutorials/near-studio/counter-smart-contract)
-
-*description*
+*Build a simple Oracle that can query external APIs and provide this data to the blockchain.*
 
 | duration | directions | difficulty |
 |:---------|:-----------|:-----------|
-| 30 mins  | ~5 steps   | Trivial    |
-
-
-### [Guest Book](/docs/tutorials/near-studio/guest-book)
-
-*description*
-
-| duration | directions | difficulty |
-|:---------|:-----------|:-----------|
-| 30 mins  | ~5 steps   | Trivial    |
+| 90 mins  | 7 steps    | Moderate   |
 
 
 ### [Issue a token](/docs/tutorials/near-studio/token)
@@ -48,9 +30,6 @@ All of these tutorials are accessible to anyone with some background in software
 | 60 mins  | 3 steps    | Moderate   |
 
 
-
-## Walkthroughs
-
 ### [Cross-Contract Calls](/docs/tutorials/how-to-write-contracts-that-talk-to-each-other)
 
 *Call functions on one smart contract from another using promises (cross contract call)*
@@ -60,16 +39,6 @@ All of these tutorials are accessible to anyone with some background in software
 | 60 mins  | 6 steps    | Moderate   |
 
 
-### [Implement an Oracle](/docs/tutorials/zero-to-hero)
-
-*Build a simple Oracle that can query external APIs and provide this data to the blockchain.*
-
-| duration | directions | difficulty |
-|:---------|:-----------|:-----------|
-| 90 mins  | 7 steps    | Moderate   |
-
-
-
 ### [Testing smart contracts](/docs/tutorials/test-your-smart-contracts)
 
 *Build a multi-player game with unit tests for core smart contract functionality*
@@ -77,3 +46,24 @@ All of these tutorials are accessible to anyone with some background in software
 | duration | directions | difficulty |
 |:---------|:-----------|:-----------|
 | 60 mins  | 4 steps    | Moderate   |
+
+
+## Helpful References
+
+
+### [Understanding Contract Structure](/docs/tutorials/near-studio/near-wallet-integration)
+
+*This page explains the basic **contract structure** created by NEAR Studio*
+
+| duration | directions | difficulty |
+|:---------|:-----------|:-----------|
+| 10 mins  | 3 sections | Trivial    |
+
+
+### [Understanding Project Structure](/docs/quick-start/development-overview)
+
+*This page explains the basic **project structure** created by NEAR Studio*
+
+| duration | directions | difficulty |
+|:---------|:-----------|:-----------|
+| 30 mins  | 6 sections | Moderate   |

--- a/docs/tutorials/near-studio/near-wallet-integration.md
+++ b/docs/tutorials/near-studio/near-wallet-integration.md
@@ -1,7 +1,7 @@
 ---
 id: near-wallet-integration
-title: Integrate with NEAR Wallet
-sidebar_label: NEAR Wallet Integration
+title: Understanding Contract Structure
+sidebar_label: Contract Structure
 ---
 
 This tutorial presents the NEAR Studio sample application called NEAR Wallet Integration

--- a/docs/tutorials/zero-to-hero.md
+++ b/docs/tutorials/zero-to-hero.md
@@ -1,7 +1,7 @@
 ---
 id: zero-to-hero
 title: Zero to Hero: Writing an Oracle
-sidebar_label: Implement an Oracle
+sidebar_label: Zero to Hero
 ---
 
 ## Tutorial Overview

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -41,24 +41,22 @@
     ],
     "Tutorials": [
       "roles/developer/tutorials/introduction",
-      "quick-start/development-overview",
       {
         "type": "subcategory",
-        "label": "Sample Applications",
+        "label": "Guided Walkthroughs",
         "ids": [
-          "tutorials/near-studio/near-wallet-integration",
-          "tutorials/near-studio/counter-smart-contract",
-          "tutorials/near-studio/guest-book",
-          "tutorials/near-studio/token"
+          "tutorials/zero-to-hero",
+          "tutorials/near-studio/token",
+          "tutorials/how-to-write-contracts-that-talk-to-each-other",
+          "tutorials/test-your-smart-contracts"
         ]
       },
       {
         "type": "subcategory",
-        "label": "Walkthroughs",
+        "label": "Helpful References",
         "ids": [
-          "tutorials/how-to-write-contracts-that-talk-to-each-other",
-          "tutorials/zero-to-hero",
-          "tutorials/test-your-smart-contracts"
+          "tutorials/near-studio/near-wallet-integration",
+          "quick-start/development-overview"
         ]
       }
     ],


### PR DESCRIPTION
based on feedback from @SkidanovAlex:
> The experience of QuickStart is not very smooth today. As a new person, I open the docs, click on "Applications Developers", and from there it's very hard to find an easy-to-follow tutorial. The best I found is zero-to-hero, but on the left it is called "Building an oracle", certainly not something I'd click if I was looking for an easy tutorial.
>
> The tutorial on the wallet integration is not a tutorial, it's more of a reference, and should certainly not be higher than zero-to-hero.

modifications:
1. modified left side nav for devs to promote walkthroughs over references, remove incomplete placeholders and bring zero-to-hero to the top
2. modified quickstart (first page they see) to promote same
3. promoted “guided walkthroughs” to introduction page and re-ordered to put zero-to-hero first
4. modified references section to include contract and project structure pages, as per your feedback and one existing page