### PR TITLE
Protobuf is not a near-core dependency.

### DIFF
--- a/docs/contribution/nearcore.md
+++ b/docs/contribution/nearcore.md
@@ -7,16 +7,6 @@ sidebar_label: NearCore
 
 **1. Dependencies**
 
-Install protobufs:
-
-```bash
-# Mac OS:
-brew install protobuf
-
-# Ubuntu:
-apt install protobuf-compiler
-```
-
 Install Rust:
 
 ```bash


### PR DESCRIPTION
We used Protobuf, but switched to our own solution for serialization (Borsh). I've checked that I'm able to run the default `near-core` w/o Protobuf.