### PR TITLE
add warning about TestNet connection disabled

### DIFF
--- a/docs/local-setup/local-dev-testnet.md
+++ b/docs/local-setup/local-dev-testnet.md
@@ -4,6 +4,14 @@ title: Local Development on TestNet
 sidebar_label: Local Development on TestNet
 ---
 
+<blockquote class="warning">
+<strong>heads up</strong><br><br>
+
+We have temporarily disabled connecting to TestNet.  This limitation may affect your ability to follow the instructions on this page.  Please [find us online](http://near.chat) if you have questions.
+
+</blockquote>
+
+
 ## Requirements
 
 **IMPORTANT: Make sure you have the latest version of NEAR Shell and Node**

--- a/docs/local-setup/running-testnet-windows.md
+++ b/docs/local-setup/running-testnet-windows.md
@@ -4,6 +4,13 @@ title: Running a Node on Windows
 sidebar_label: Running a Node on Windows
 ---
 
+<blockquote class="warning">
+<strong>heads up</strong><br><br>
+
+We have temporarily disabled connecting to TestNet.  This limitation may affect your ability to follow the instructions on this page.  Please [find us online](http://near.chat) if you have questions.
+
+</blockquote>
+
 #### This page outlines the steps involved on setting up a local node on Windows
 
 1.  If Windows Subsystem for Linux is not enabled, open PowerShell as administrator and run:

--- a/docs/local-setup/running-testnet.md
+++ b/docs/local-setup/running-testnet.md
@@ -4,6 +4,13 @@ title: Running a node
 sidebar_label: Running a node
 ---
 
+<blockquote class="warning">
+<strong>heads up</strong><br><br>
+
+We have temporarily disabled connecting to TestNet.  This limitation may affect your ability to follow the instructions on this page.  Please [find us online](http://near.chat) if you have questions.
+
+</blockquote>
+
 ## Intro
 
 This will teach you how to set up a node that syncs with the official TestNet. You can take a look at the core code found here: [https://github.com/nearprotocol/nearcore](https://github.com/nearprotocol/nearcore)


### PR DESCRIPTION
@mikedotexe 
> Stale question in Discord around validator nodes. 
> https://discordapp.com/channels/490367152054992913/557983089704566787/681327728041263133 (edited) 

@bowenwang1996 
> We disabled connecting to testnet for now. I think someone needs to thoughtfully construct a comprehensive answer for this question

@amgando 
> does it make sense to post a clear notice in the docs pages where we talk about TestNet?

@bowenwang1996 
> Yes