### PR TITLE
exclude youtube from link-checker as it throws 429's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ script:
   - cd website; yarn install; yarn build
   - npx serve build/near-docs &
   - npx wait-on http://localhost:5000/
-  - npx broken-link-checker -gro --exclude "localhost:3030" --exclude "https://github.com/nearprotocol/docs/tree/master/docs" --host-requests 2 http://localhost:5000
+  - npx broken-link-checker -gro --exclude "localhost:3030" --exclude "https://github.com/nearprotocol/docs/tree/master/docs" --exclude "https://youtu.be" --exclude "http://near.ai/wbs" --exclude "https://www.youtube.com" --host-requests 2 http://localhost:5000


### PR DESCRIPTION
also a redirect to youtube: near.ai/wbs

---
Travis has been throwing many 429 errors because of too many requests when it tries to check broken links. This excludes youtube links and the link mentioned in the first line of this PR.