### PR TITLE
remove instruction to checkout staging on local setup

### DIFF
--- a/docs/local-setup/running-testnet.md
+++ b/docs/local-setup/running-testnet.md
@@ -44,11 +44,6 @@ git clone https://github.com/nearprotocol/nearcore.git
 cd nearcore
 ```
 
-`checkout` to latest development version of start script:
-```bash
-git checkout staging
-```
-
 To enable coredump for docker, do `echo '/tmp/core.%t.%e.%p' | sudo tee /proc/sys/kernel/core_pattern` to modify system coredump location to `/tmp`.
 
 and then run `./scripts/start_testnet.py`

--- a/docs/local-setup/running-testnet.md
+++ b/docs/local-setup/running-testnet.md
@@ -44,6 +44,11 @@ git clone https://github.com/nearprotocol/nearcore.git
 cd nearcore
 ```
 
+`checkout` to latest development version of start script:
+```bash
+git checkout staging
+```
+
 To enable coredump for docker, do `echo '/tmp/core.%t.%e.%p' | sudo tee /proc/sys/kernel/core_pattern` to modify system coredump location to `/tmp`.
 
 and then run `./scripts/start_testnet.py`

--- a/docs/local-setup/running-testnet.md
+++ b/docs/local-setup/running-testnet.md
@@ -46,7 +46,7 @@ cd nearcore
 
 `checkout` to latest development version of start script:
 ```bash
-git checkout staging
+git checkout stable
 ```
 
 To enable coredump for docker, do `echo '/tmp/core.%t.%e.%p' | sudo tee /proc/sys/kernel/core_pattern` to modify system coredump location to `/tmp`.


### PR DESCRIPTION
Very simple, as the title says. There must have once been a time where it made sense to checkout staging, but I've been instructed to remove this.