### PR TITLE
remove near bindgen link to limitations anchor in readme

### DIFF
--- a/docs/near-bindgen/near-bindgen.md
+++ b/docs/near-bindgen/near-bindgen.md
@@ -19,8 +19,6 @@ sidebar_label: Rust
       <a href="https://github.com/nearprotocol/near-bindgen#writing-rust-contract">Writing Rust Contract</a>
       <span> | </span>
       <a href="https://github.com/nearprotocol/near-bindgen#building-rust-contract">Building Rust Contract</a>
-      <span> | </span>
-      <a href="https://github.com/nearprotocol/near-bindgen#running-rust-contract">Running Rust Contract</a>
     </h3>
 </div>
 

--- a/docs/near-bindgen/near-bindgen.md
+++ b/docs/near-bindgen/near-bindgen.md
@@ -21,8 +21,6 @@ sidebar_label: Rust
       <a href="https://github.com/nearprotocol/near-bindgen#building-rust-contract">Building Rust Contract</a>
       <span> | </span>
       <a href="https://github.com/nearprotocol/near-bindgen#running-rust-contract">Running Rust Contract</a>
-      <span> | </span>
-      <a href="https://github.com/nearprotocol/near-bindgen#limitations-and-future-work">Limitations and Future Work</a>
     </h3>
 </div>
 


### PR DESCRIPTION
Minor removal of an anchor link that is no longer there.