### PR TITLE
fix: use example app name

### DIFF
--- a/docs/quick-start/create-near-app.md
+++ b/docs/quick-start/create-near-app.md
@@ -9,8 +9,8 @@ Setup a NEAR Protocol web app template using one command, `npx create-near-app`.
 4 steps to success:
 
 ```text
-npx create-near-app <your-awesome-project>
-cd <your-awesome-project>
+npx create-near-app my-awesome-project
+cd my-awesome-project
 yarn
 yarn dev
 ```


### PR DESCRIPTION
The bracketed placeholders don't currently show up on our compiled docs at https://docs.nearprotocol.com/docs/quick-start/create-near-app

Even if they did, they're probably a bad idea, since < and > have meanings in bash and other shells, and if someone misunderstands and pastes these commands as-is into their shell, they will get unexpected results

Using an actual example name seems fine – if they paste these commands as-is, they may have a project name that they don't like, but that's easy to figure out and fix