### PR TITLE
fix(rpc): Removed an outdated RPC warning

### DIFF
--- a/docs/api/rpc-experimental.md
+++ b/docs/api/rpc-experimental.md
@@ -9,8 +9,6 @@ sidebar_label: Experimental Methods
 
 This page refers to a **technical preview**.
 
-These features are not currently available on TestNet. They will be available in an upcoming release.
-
 </blockquote>
 
 ## Changes in Block


### PR DESCRIPTION
NOTE: The rest of the message is true up until we decide to remove the EXPERIMENTAL_ prefix from the naming.